### PR TITLE
Performance fixes

### DIFF
--- a/auspixdggs/auspixengine/projection_wrapper.py
+++ b/auspixdggs/auspixengine/projection_wrapper.py
@@ -64,6 +64,12 @@ class Proj(object):
     f(u, v, radians=False, inverse=False).
     For example, see the healpix() function in ``pj_healpix.py``.
     """
+    # Provide a cache of the inner proj object for performance
+    cache_a = None
+    cache_e = None
+    cache_proj_type = None
+    cache_proj = None
+    cache_kwargs = None
     def __init__(self, ellipsoid=WGS84_ELLIPSOID, proj=None, **kwargs):
         self.proj = proj
         # Keyword arguments related to the projection but not to its
@@ -106,7 +112,16 @@ class Proj(object):
                 return
         else:
             # Use a projection from the PROJ.4 library.
-            f = pyproj.Proj(proj=proj, a=a, e=e, **kwargs)
+            # If the Proj object doesn't need to be recreate use the existing one
+            if Proj.cache_kwargs == kwargs and Proj.cache_a == a and Proj.cache_e == e and Proj.cache_proj_type == proj:
+                f = Proj.cache_proj
+            else:
+                Proj.cache_a = a
+                Proj.cache_e = e
+                Proj.cache_proj_type = proj
+                Proj.cache_kwargs = kwargs 
+                Proj.cache_proj = f = pyproj.Proj(proj=proj, a=a, e=e, **kwargs)
+
         if not inverse:
             # Translate longitudes and latitudes so that 
             # (lon_0, lat_0) maps to (0, 0) in the plane.

--- a/auspixdggs/callablemodules/dggs_in_poly.py
+++ b/auspixdggs/callablemodules/dggs_in_poly.py
@@ -47,7 +47,7 @@ def point_set_from_bounds(resolution, ul, dr):
     # designed to replace rdggs.cells_from_region - which didn't work in the S (Antartic) zone 
     # a function to fill a bounding box with xy values (pointset) as seed points to build the set of cells from
     # works across the R to S divide even in the same polygon
-    step = 0.0001  # adjust step to suit DGGS resolution  in degrees Lat long - need improvement to help speed it up too
+    step = 0.0001 # adjust step to suit DGGS resolution  in degrees Lat long - need improvement to help speed it up too
     if resolution == 10:
         step = 0.0015  # OK setting for resolution 10
     pointset = []
@@ -78,11 +78,11 @@ def poly_to_DGGS_tool(myPoly, resolution):  # one poly and the attribute record 
     #print('nw', nw, 'se', se)
 
     bbox_myPoints = point_set_from_bounds(resolution, nw, se)
-    cell_list = []
+    cell_list = {} 
     for pt in bbox_myPoints:
         thiscell = rdggs.cell_from_point(resolution, pt, plane=False)
-        if thiscell not in cell_list:
-            cell_list.append(thiscell)
+        cell_string = str(thiscell)
+        cell_list[cell_string] = thiscell
 
 
     # # call function to calculate all the cells within the bounding box  - this function is not working properly in the S area
@@ -98,7 +98,7 @@ def poly_to_DGGS_tool(myPoly, resolution):  # one poly and the attribute record 
 
     # now find the centroids of those cells using dggs engine
     bboxCentroids = list() # declare a container to hold bbox centriods list for all the cells
-    for cell in cell_list:  # for each cell in the bounding box
+    for cell in cell_list.values():  # for each cell in the bounding box
         # print(cell, cell.nucleus(plane=False))
         location = cell.nucleus(plane=False)  # on the ellipsoid
         # make a list of cell location and x and y
@@ -239,7 +239,6 @@ if __name__ == '__main__':
 
     index = 0
     for fea in irrPolys:  # for feature in attribute table
-
             cells = poly_to_DGGS_tool(fea.shape, 10)  # start at DGGS level 10
 
     # for item in cellsInPoly:


### PR DESCRIPTION
I've profiled poly_to_DGGS_tool out of that I've implemented 2 performance fixes, a cache so that the  pyproj.Proj object isn't recreated each time a projection transformation happens, and a much faster way of creating a unique list of dggs cells containing the points in the "search" point set grid. In testing this speeds performance up by about 15 times for a small simple test polygon. More work might be needed to bring performance of the API close to "web" time for even relatively simple and small input polygons. If this looks ok we could create a new pull request against the GeoscienceAustralia/AusPIX_DGGS repository.